### PR TITLE
List (& dict) comparison tests/fixes

### DIFF
--- a/tests/helpers/test_validation.py
+++ b/tests/helpers/test_validation.py
@@ -49,6 +49,72 @@ class TestValidation(TestCase):
         # Then
         self.assertTrue(result)
 
+    def test_matches_MatchingListOfStrings_ReturnsTrue(self):
+        # Given
+        expected = ['foo']
+        actual = ['foo']
+
+        # When
+        result = validation.matches(expected, actual)
+
+        # Then
+        self.assertTrue(result)
+
+    def test_matches_MatchingListOfDicts_ReturnsTrue(self):
+        # Given
+        expected = [{'foo': 'bar'}]
+        actual = [{'foo': 'bar'}]
+
+        # When
+        result = validation.matches(expected, actual)
+
+        # Then
+        self.assertTrue(result)
+
+    def test_matches_MatchingListOfLists_ReturnsTrue(self):
+        # Given
+        expected = [['foo']]
+        actual = [['foo']]
+
+        # When
+        result = validation.matches(expected, actual)
+
+        # Then
+        self.assertTrue(result)
+
+    def test_matches_MatchingListOfStringsOutOfOrder_ReturnsTrue(self):
+        # Given
+        expected = ['foo', 'bar']
+        actual = ['bar', 'foo']
+
+        # When
+        result = validation.matches(expected, actual)
+
+        # Then
+        self.assertTrue(result)
+
+    def test_matches_MatchingListOfDictsOutOfOrder_ReturnsTrue(self):
+        # Given
+        expected = [{'foo': 'bar'}, {'bazz': 'buzz'}]
+        actual = [{'bazz': 'buzz'}, {'foo': 'bar'}]
+
+        # When
+        result = validation.matches(expected, actual)
+
+        # Then
+        self.assertTrue(result)
+
+    def test_matches_MatchingListOfListsOutOfOrder_ReturnsTrue(self):
+        # Given
+        expected = [['foo'], ['bar']]
+        actual = [['bar'], ['foo']]
+
+        # When
+        result = validation.matches(expected, actual)
+
+        # Then
+        self.assertTrue(result)
+
     def test_matches_NonMatchingStrings_ReturnsFalse(self):
         # Given
         expected = 'foo'

--- a/tests/helpers/test_validation.py
+++ b/tests/helpers/test_validation.py
@@ -156,6 +156,36 @@ class TestValidation(TestCase):
         # Then
         self.assertFalse(result)
 
+    def test_matches_NonMatchingDictValueTypesExpectListActualDict_ReturnsFalse(self):
+        # Given
+        expected = {
+            'foo': ['bar']
+        }
+        actual = {
+            'foo': {'bar': 'bar'}
+        }
+
+        # When
+        result = validation.matches(expected, actual)
+
+        # Then
+        self.assertFalse(result)
+
+    def test_matches_NonMatchingDictValueTypesExpectDictActualList_ReturnsFalse(self):
+        # Given
+        expected = {
+            'foo': {'bar': 'bar'}
+        }
+        actual = {
+            'foo': ['bar']
+        }
+
+        # When
+        result = validation.matches(expected, actual)
+
+        # Then
+        self.assertFalse(result)
+
     def test_matches_MatchingNestedDict_ReturnsTrue(self):
         # Given
         expected = {

--- a/tests/helpers/test_validation.py
+++ b/tests/helpers/test_validation.py
@@ -115,6 +115,39 @@ class TestValidation(TestCase):
         # Then
         self.assertTrue(result)
 
+    def test_matches_MatchingListWithANY_ReturnsTrue(self):
+        # Given
+        expected = ['foo', validation.ANY, 'bar']
+        actual = ['foo', 'bazz', 'bar']
+
+        # When
+        result = validation.matches(expected, actual)
+
+        # Then
+        self.assertTrue(result)
+
+    def test_matches_NonMatchingListWithANY_ReturnsFalse(self):
+        # Given
+        expected = ['foo', validation.ANY, 'bar']
+        actual = ['foo', 'bazz', 'buzz']
+
+        # When
+        result = validation.matches(expected, actual)
+
+        # Then
+        self.assertFalse(result)
+
+    def test_matches_MatchingListWithMultipleANY_ReturnsTrue(self):
+        # Given
+        expected = ['foo', validation.ANY, validation.ANY]
+        actual = ['foo', 'bazz', 'bar']
+
+        # When
+        result = validation.matches(expected, actual)
+
+        # Then
+        self.assertTrue(result)
+
     def test_matches_NonMatchingStrings_ReturnsFalse(self):
         # Given
         expected = 'foo'

--- a/touchstone/helpers/validation.py
+++ b/touchstone/helpers/validation.py
@@ -10,12 +10,13 @@ def __equals(expected, actual) -> bool:
 def __equals_list(expected: list, actual: list) -> bool:
     if len(expected) != len(actual):
         return False
-    for item in expected:
-        if isinstance(item, dict):
-            for actual_item in actual:
-                if isinstance(actual_item, dict) and not __equals_dict(item, actual_item):
-                    return False
-        elif not __equals(item, actual):
+    for expected_item in expected:
+        expected_item_in_actual = False
+        for actual_item in actual:
+            if matches(expected_item, actual_item, quiet = True):
+                expected_item_in_actual = True
+                break
+        if not expected_item_in_actual:
             return False
     return True
 

--- a/touchstone/helpers/validation.py
+++ b/touchstone/helpers/validation.py
@@ -27,13 +27,7 @@ def __equals_dict(expected: dict, actual: dict) -> bool:
     for k, v in expected.items():
         if k not in actual:
             return False
-        if isinstance(v, dict):
-            if not __equals_dict(v, actual[k]):
-                return False
-        elif isinstance(v, list):
-            if not __equals_list(v, actual[k]):
-                return False
-        elif not __equals(v, actual[k]):
+        if not matches(v, actual[k], quiet = True):
             return False
     return True
 


### PR DESCRIPTION
Added explicit test cases for different types being compared in lists: single-value types (string used in practice), lists, and dicts. Test cases cover both "can lists of these be compared" (with just one element) and "can lists of these be compared out of order".

Five of the six cases (used to) fail; only the single dict case passes.

Similarly added tests for cases where the types of dicts' values are different – these were getting delegated to the comparison function for the type of the expected item even if the actual item is a different type. (It is _possible_ that one of the tests might actually pass because the comparison method selected happens to be valid for use against the other type and return False "by accident"; fixing this should guarantee we get correct equals comparison for type mismatches, which should always return False by design.)

Then, added fixes for both – they now delegate to `matches` with `quiet = True` for the value comparison so types are handled correctly, and list comparison returns `False` if any item in expected does not match any item in actual (otherwise returns True if lengths are the same and all items in expected match an item in actual).