### PR TITLE
rm explicitly after retrieving logs instead of with --rm

### DIFF
--- a/touchstone/lib/managers/docker_manager.py
+++ b/touchstone/lib/managers/docker_manager.py
@@ -96,7 +96,7 @@ class DockerManager(object):
 
     def __run_image(self, additional_params: str, image: str, hostname: str = None) -> str:
         container_id = uuid.uuid4().hex
-        command = f'docker run --rm -d --network {self.__network} '
+        command = f'docker run -d --network {self.__network} '
         if hostname:
             command += f'--hostname {hostname} '
         command += f'--name {container_id} {additional_params} {image}'
@@ -139,6 +139,7 @@ class DockerManager(object):
                 subprocess.run(['docker', 'container', 'logs', id], stdout=file)
         common.logger.debug(f'Stopping container: {id}')
         subprocess.run(['docker', 'container', 'stop', id], stdout=subprocess.DEVNULL)
+        subprocess.run(['docker', 'container', 'rm', '-v', id], stdout=subprocess.DEVNULL)
         self.__containers.remove(id)
 
     def cleanup(self):


### PR DESCRIPTION
Fixes #36 by allowing a crashed container to stick around till the logs are captured and the container is destroyed in the stopping step.

Has two disadvantages:

- There is an increased risk of orphaning the container if something catastrophic happens to Touchstone such that it can't run the container stop subroutine, since Docker no longer autoremoves it.
- The logs are not available until the service stops. This is the status quo currently, but #43 improves on this by beginning to capture the logs to the file immediately.