### PR TITLE
Log services as they run (start capturing output immediately)

### DIFF
--- a/touchstone/lib/managers/docker_manager.py
+++ b/touchstone/lib/managers/docker_manager.py
@@ -37,7 +37,7 @@ class DockerManager(object):
 
     def run_background_image(self, image: str, port: int = None, exposed_port: int = None, ui_port: int = None,
                              environment_vars: List[Tuple[str, str]] = [], hostname: str = None,
-                             options: str = None) -> RunResult:
+                             log_path: str = None, options: str = None) -> RunResult:
         exposed_port = port if not exposed_port else exposed_port
         self.__create_network()
 
@@ -49,7 +49,7 @@ class DockerManager(object):
             additional_params += ' '
             additional_params += options
 
-        container_id = self.__run_image(additional_params, image, hostname)
+        container_id = self.__run_image(additional_params, image, log_path, hostname)
 
         # Extract the auto-discovered ports
         exposed_port = self.__extract_port_mapping(container_id, port)
@@ -94,7 +94,7 @@ class DockerManager(object):
             additional_params += f' -e {var}="{value}"'
         return additional_params[1:]
 
-    def __run_image(self, additional_params: str, image: str, hostname: str = None) -> str:
+    def __run_image(self, additional_params: str, image: str, log_path: Optional[str], hostname: str = None) -> str:
         container_id = uuid.uuid4().hex
         command = f'docker run --rm -d --network {self.__network} '
         if hostname:
@@ -102,6 +102,10 @@ class DockerManager(object):
         command += f'--name {container_id} {additional_params} {image}'
         common.logger.debug(f'Running container with command: {command}')
         result = subprocess.run(command, shell=True, stdout=subprocess.DEVNULL)
+        if log_path:
+            common.logger.debug(f'Writing container logs: {log_path}')
+            with open(log_path, 'w') as file:
+                subprocess.Popen(['docker', 'container', 'logs', '--follow', container_id], stdout=file)
         if result.returncode is not 0:
             raise exceptions.ContainerException(
                 f'Container image {image} could not be started. Ensure Docker is running and ports are not already in '
@@ -132,11 +136,7 @@ class DockerManager(object):
                 return new_port
         return given_port
 
-    def stop_container(self, id: str, log_path: str = None):
-        if log_path:
-            common.logger.debug(f'Writing container logs: {log_path}')
-            with open(log_path, 'w') as file:
-                subprocess.run(['docker', 'container', 'logs', id], stdout=file)
+    def stop_container(self, id: str):
         common.logger.debug(f'Stopping container: {id}')
         subprocess.run(['docker', 'container', 'stop', id], stdout=subprocess.DEVNULL)
         self.__containers.remove(id)

--- a/touchstone/lib/nodes/services/docker/docker_runnable_service.py
+++ b/touchstone/lib/nodes/services/docker/docker_runnable_service.py
@@ -60,19 +60,20 @@ class DockerRunnableService(IService, ITestable, IRunnable, INetworkable):
         elif self.__docker_image is not None:
             self.__log('Running Docker image...')
             docker_artifact = self.__docker_image
+        log_path = None
+        if self.__log_directory:
+            log_path = os.path.join(self.__log_directory, f'{self.__name}.log')
         run_result = self.__docker_manager.run_background_image(docker_artifact, self.__port,
                                                                 environment_vars=environment_vars,
                                                                 hostname=self.__name,
+                                                                log_path=log_path,
                                                                 options=self.__docker_options)
         self.__docker_network.set_container_id(run_result.container_id)
         self.__docker_network.set_external_port(run_result.external_port)
 
     def stop(self):
         if self.__docker_network.container_id():
-            log_path = None
-            if self.__log_directory:
-                log_path = os.path.join(self.__log_directory, f'{self.__name}.log')
-            self.__docker_manager.stop_container(self.__docker_network.container_id(), log_path)
+            self.__docker_manager.stop_container(self.__docker_network.container_id())
             self.__docker_network.set_container_id(None)
 
     def is_running(self) -> bool:


### PR DESCRIPTION
Fixes #36 by asking Docker to pipe the logs to a file as the next action after attempting to start the container.

The disadvantage of this approach is that, as long as we're using `docker container logs --follow` instead of piping the container run command itself to the file, there's a remote possibility that a startup failure could be missed if it is literally faster than the time it takes for Docker+Python to finish the run CLI command and execute the logs command.

That could theoretically be fixed by changing the strategy internal to `__run_image`.

See also #42